### PR TITLE
Fix for Extra Chapter* generation for bibliography 

### DIFF
--- a/SOICTthesis.cls
+++ b/SOICTthesis.cls
@@ -280,7 +280,9 @@
 }
 % ----- End of TOC Formatting -----
 % Biblography Formatting
-
+\makeatletter
+\patchcmd{\thebibliography}{\chapter*}{\section*}{}{}
+\makeatother
 
 % ----- End of Class -----
 \endinput


### PR DESCRIPTION
Replaced `\chapter*` with `\section*` in `\thebibliography` using `\patchcmd` to fix automatic chapter generation issue.